### PR TITLE
Phase 4 supabase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vercel
 .env*.local
+.worktrees/

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -56,7 +56,7 @@ One exported object; all public content and links read from it. One file swap pe
 ## 3. Auth, client portal, admin
 
 - **Auth:** Supabase Auth (email/password; magic link optional). `/login` redirects by role (client → `/portal`, admin → `/admin`).
-- **Roles:** Resolved from `fit-accounting-demo.profiles` by `auth.uid()`. Middleware protects `/portal` (client or admin) and `/admin` (admin only).
+- **Roles:** Resolved from `fit_accounting_demo.profiles` by `auth.uid()`. Middleware protects `/portal` (client or admin) and `/admin` (admin only).
 - **Client portal:** Upload (Supabase Storage + metadata), downloads list (forms/docs), optional “Your submissions” with status.
 - **Admin:** Clients list; per-client uploads with download and “Mark as reviewed”; optional upload of portal downloads/forms. No inbox; manual workflow.
 - No FIT Automate ongoing maintenance (no scheduled jobs, no n8n).
@@ -65,7 +65,7 @@ One exported object; all public content and links read from it. One file swap pe
 
 ## 4. Supabase schema & RLS
 
-**Schema:** `fit-accounting-demo`.
+**Schema:** `fit_accounting_demo`.
 
 **Tables:**
 
@@ -110,18 +110,18 @@ No other Vercel-specific config required for a standard Next.js App Router app.
 
 **You need to do:**
 
-1. **Schema:** Create schema `fit-accounting-demo` and run migrations (tables + RLS + storage buckets) in that project.
+1. **Schema:** Create schema `fit_accounting_demo` and run migrations (tables + RLS + storage buckets) in that project. Phase 4.1 migration file: `supabase/migrations/20260317_fit_accounting_demo_schema.sql`.
 2. **Auth redirect URLs:** In Supabase Dashboard → Auth → URL Configuration → Redirect URLs, add:
    - Production: `https://liquid-financial-demo.vercel.app/login` (or final domain)
    - Preview: `https://*.vercel.app/login` if you use preview deployments
    - Local: `http://localhost:3000/login` (or your dev port)
    - Also add these to `.agent/platforms/supabase.yaml` under `auth_redirect_urls`.
-3. **Expose schema:** Ensure `fit-accounting-demo` is in `pgrst.db_schemas` for the project (and in `schemas` in `supabase.yaml`).
+3. **Expose schema:** Ensure `fit_accounting_demo` is in `pgrst.db_schemas` for the project (and in `schemas` in `supabase.yaml`).
 4. **Env in Vercel (and local):** Set:
    - `NEXT_PUBLIC_SUPABASE_URL` = project URL (no path)
    - `NEXT_PUBLIC_SUPABASE_ANON_KEY` = anon key
    - `SUPABASE_SERVICE_ROLE_KEY` = service role key (server-only; for admin and RLS bypass where needed)
-   - Optional: `SUPABASE_DB_SCHEMA=fit-accounting-demo` if your client defaults to it
+   - Optional: `SUPABASE_DB_SCHEMA=fit_accounting_demo` if your client defaults to it
 
 **Summary:** Supabase is “connected” once (a) the schema and policies exist in the existing project, (b) redirect URLs include this app’s URLs, and (c) the app’s env vars point at that project. No separate “connect” step in Vercel for Supabase; connection is via env vars.
 
@@ -149,7 +149,7 @@ No other Vercel-specific config required for a standard Next.js App Router app.
 
 ### Supabase (shared project)
 
-- [ ] Create schema `fit_accounting_demo` and run migrations (tables + RLS)
+- [ ] Create schema `fit_accounting_demo` and run migrations (tables + RLS), including `supabase/migrations/20260317_fit_accounting_demo_schema.sql`
 - [ ] Create storage buckets `client-uploads`, `portal-downloads` with RLS
 - [ ] Add Auth redirect URLs (see §7) in Dashboard and in `.agent/platforms/supabase.yaml`
 - [ ] Insert Stanley's admin profile after first login (user_id from Auth)

--- a/supabase/migrations/20260317_fit_accounting_demo_schema.sql
+++ b/supabase/migrations/20260317_fit_accounting_demo_schema.sql
@@ -1,0 +1,147 @@
+begin;
+
+create extension if not exists pgcrypto;
+
+create schema if not exists fit_accounting_demo;
+
+create table if not exists fit_accounting_demo.profiles (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null unique references auth.users (id) on delete cascade,
+  role text not null default 'client' check (role in ('client', 'admin')),
+  full_name text,
+  email text,
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+create table if not exists fit_accounting_demo.contact_submissions (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default timezone('utc', now()),
+  name text not null,
+  email text not null,
+  subject text not null,
+  message text not null
+);
+
+create table if not exists fit_accounting_demo.client_documents (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users (id) on delete cascade,
+  filename text not null,
+  storage_path text not null,
+  uploaded_at timestamptz not null default timezone('utc', now()),
+  status text not null default 'received' check (status in ('received', 'under_review', 'complete'))
+);
+
+create table if not exists fit_accounting_demo.portal_downloads (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  description text,
+  storage_path text not null,
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+create index if not exists client_documents_user_id_idx
+  on fit_accounting_demo.client_documents (user_id);
+
+create or replace function fit_accounting_demo.is_admin(check_user_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = fit_accounting_demo, public
+as $$
+  select exists (
+    select 1
+    from fit_accounting_demo.profiles profile_row
+    where profile_row.user_id = check_user_id
+      and profile_row.role = 'admin'
+  );
+$$;
+
+grant usage on schema fit_accounting_demo to anon, authenticated, service_role;
+grant execute on function fit_accounting_demo.is_admin(uuid) to authenticated, service_role;
+
+grant select on fit_accounting_demo.profiles to authenticated;
+grant insert on fit_accounting_demo.contact_submissions to anon, authenticated;
+grant select, insert on fit_accounting_demo.client_documents to authenticated;
+grant select on fit_accounting_demo.portal_downloads to authenticated;
+
+grant all privileges on all tables in schema fit_accounting_demo to service_role;
+grant all privileges on all sequences in schema fit_accounting_demo to service_role;
+alter default privileges in schema fit_accounting_demo
+  grant all privileges on tables to service_role;
+alter default privileges in schema fit_accounting_demo
+  grant all privileges on sequences to service_role;
+
+alter table fit_accounting_demo.profiles enable row level security;
+alter table fit_accounting_demo.contact_submissions enable row level security;
+alter table fit_accounting_demo.client_documents enable row level security;
+alter table fit_accounting_demo.portal_downloads enable row level security;
+
+drop policy if exists profiles_select_own on fit_accounting_demo.profiles;
+create policy profiles_select_own
+  on fit_accounting_demo.profiles
+  for select
+  to authenticated
+  using (auth.uid() = user_id);
+
+drop policy if exists contact_insert_public on fit_accounting_demo.contact_submissions;
+create policy contact_insert_public
+  on fit_accounting_demo.contact_submissions
+  for insert
+  to anon, authenticated
+  with check (true);
+
+drop policy if exists contact_select_admin on fit_accounting_demo.contact_submissions;
+create policy contact_select_admin
+  on fit_accounting_demo.contact_submissions
+  for select
+  to authenticated
+  using (fit_accounting_demo.is_admin(auth.uid()));
+
+drop policy if exists client_documents_select_own_or_admin on fit_accounting_demo.client_documents;
+create policy client_documents_select_own_or_admin
+  on fit_accounting_demo.client_documents
+  for select
+  to authenticated
+  using (
+    user_id = auth.uid()
+    or fit_accounting_demo.is_admin(auth.uid())
+  );
+
+drop policy if exists client_documents_insert_own_or_admin on fit_accounting_demo.client_documents;
+create policy client_documents_insert_own_or_admin
+  on fit_accounting_demo.client_documents
+  for insert
+  to authenticated
+  with check (
+    user_id = auth.uid()
+    or fit_accounting_demo.is_admin(auth.uid())
+  );
+
+drop policy if exists client_documents_update_admin on fit_accounting_demo.client_documents;
+create policy client_documents_update_admin
+  on fit_accounting_demo.client_documents
+  for update
+  to authenticated
+  using (fit_accounting_demo.is_admin(auth.uid()))
+  with check (fit_accounting_demo.is_admin(auth.uid()));
+
+drop policy if exists portal_downloads_select_authenticated on fit_accounting_demo.portal_downloads;
+create policy portal_downloads_select_authenticated
+  on fit_accounting_demo.portal_downloads
+  for select
+  to authenticated
+  using (true);
+
+drop policy if exists portal_downloads_write_admin on fit_accounting_demo.portal_downloads;
+create policy portal_downloads_write_admin
+  on fit_accounting_demo.portal_downloads
+  for all
+  to authenticated
+  using (fit_accounting_demo.is_admin(auth.uid()))
+  with check (fit_accounting_demo.is_admin(auth.uid()));
+
+alter role authenticator set pgrst.db_schemas = 'public, n8n_inventory, fit_accounting_demo';
+notify pgrst, 'reload schema';
+
+commit;


### PR DESCRIPTION
Phase 4.1 is done on branch phase-4-supabase and pushed.

Implemented migration: added supabase/migrations/20260317_fit_accounting_demo_schema.sql with:
schema creation for fit_accounting_demo
tables: profiles, contact_submissions, client_documents, portal_downloads
grants for anon, authenticated, service_role
RLS enablement + policies for client/admin access patterns
helper function fit_accounting_demo.is_admin(...)
PostgREST exposure update via alter role authenticator set pgrst.db_schemas = 'public, n8n_inventory, fit_accounting_demo' + notify pgrst, 'reload schema'
Docs aligned: updated docs/DESIGN.md to use fit_accounting_demo consistently and reference the new migration file.
Committed: 3c0370e — feat(supabase): add fit_accounting_demo schema migration and RLS
Pushed: origin/phase-4-supabase